### PR TITLE
fix: evaluate client creds token expiry period in seconds instead of ms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-We are not accepting new Pull Requests for the time being. Please raise an issue or contact us in the [support community](https://discord.gg/8naAwJfWN6) instead.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,8 +1,0 @@
-# Security Policy
-
-This document outlines the Responsible Disclosure Program for OpenFGA.
-
-## Responsible Disclosure Policy
-
-
-## Reporting a vulnerability

--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -3,8 +3,6 @@
 .github/CODEOWNERS
 .github/ISSUE_TEMPLATES/bug_report.md
 .github/ISSUE_TEMPLATES/feature_request.md
-.github/PULL_REQUEST_TEMPLATE.md
-.github/SECURITY.md
 .github/workflows/main.yaml
 .github/workflows/semgrep.yaml
 .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.4
+
+### [0.2.4](https://github.com/openfga/dotnet-sdk/compare/v0.2.3...v0.2.4) (2023-05-01)
+- fix: client credentials token expiry period was being evaluated as ms instead of seconds, leading to token refreshes on every call
+
 ## v0.2.3
 
 ### [0.2.3](https://github.com/openfga/dotnet-sdk/compare/v0.2.2...v0.2.3) (2023-04-13)

--- a/src/OpenFga.Sdk/ApiClient/OAuth2Client.cs
+++ b/src/OpenFga.Sdk/ApiClient/OAuth2Client.cs
@@ -131,7 +131,7 @@ public class OAuth2Client {
 
         _authToken = new AuthToken() {
             AccessToken = accessTokenResponse.AccessToken,
-            ExpiresAt = DateTime.Now + TimeSpan.FromMilliseconds(accessTokenResponse.ExpiresIn)
+            ExpiresAt = DateTime.Now + TimeSpan.FromSeconds(accessTokenResponse.ExpiresIn)
         };
     }
 

--- a/src/OpenFga.Sdk/Client/Client.cs
+++ b/src/OpenFga.Sdk/Client/Client.cs
@@ -26,7 +26,6 @@ public class OpenFgaClient : IDisposable {
     private string CLIENT_METHOD_HEADER = "X-OpenFGA-Client-Method";
 
     private readonly int DEFAULT_MAX_METHOD_PARALLEL_REQS = 10;
-    private readonly int DEFAULT_WAIT_TIME_BETWEEN_CHUNKS_IN_MS = 100;
 
     public OpenFgaClient(
         ClientConfiguration configuration,

--- a/src/OpenFga.Sdk/Configuration/Configuration.cs
+++ b/src/OpenFga.Sdk/Configuration/Configuration.cs
@@ -60,7 +60,7 @@ public class Configuration {
     ///     Version of the package.
     /// </summary>
     /// <value>Version of the package.</value>
-    public const string Version = "0.2.3";
+    public const string Version = "0.2.4";
 
     #endregion Constants
 

--- a/src/OpenFga.Sdk/OpenFga.Sdk.csproj
+++ b/src/OpenFga.Sdk/OpenFga.Sdk.csproj
@@ -12,7 +12,7 @@
     <Description>.NET SDK for OpenFGA</Description>
     <Copyright>OpenFGA</Copyright>
     <RootNamespace>OpenFga.Sdk</RootNamespace>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\OpenFga.Sdk.xml</DocumentationFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Closes https://github.com/openfga/dotnet-sdk/issues/19

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
