### PR TITLE
chore: add test to cover not sending empty array when other has data

### DIFF
--- a/src/OpenFga.Sdk.Test/Client/OpenFgaClientTests.cs
+++ b/src/OpenFga.Sdk.Test/Client/OpenFgaClientTests.cs
@@ -805,6 +805,7 @@ public class OpenFgaClientTests {
                     Object = "document:roadmap",
                 }
             },
+            Deletes = new List<ClientTupleKeyWithoutCondition>(), // should not get passed
         };
         var response = await fgaClient.Write(body, new ClientWriteOptions {
             AuthorizationModelId = "01GXSA8YR785C4FYS3C0RTG7B1",


### PR DESCRIPTION
## Description

Adds the `Deletes` property to the test to ensure that we don't pass this when it is empty. Given that we don't match on body this isn't really much gain but it will help to ensure we maintain this in future if we improve testing.

## References


Part of https://github.com/openfga/sdk-generator/issues/299
Generated from https://github.com/openfga/sdk-generator/pull/306

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
