### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.4.0
+
+### [0.4.0](https://github.com/openfga/dotnet-sdk/compare/v0.3.2...v0.4.0) (2024-06-14)
+- chore!: remove excluded users from ListUsers response
+
+BREAKING CHANGE:
+
+This version removes the `ExcludedUsers` field from the `ListUsersResponse` and `ClientListUsersResponse` classes,
+for more details see the [associated API change](https://github.com/openfga/api/pull/171).
+
 ## v0.3.2
 
 ### [0.3.2](https://github.com/openfga/dotnet-sdk/compare/v0.3.1...v0.3.2) (2024-04-30)

--- a/src/OpenFga.Sdk/Configuration/Configuration.cs
+++ b/src/OpenFga.Sdk/Configuration/Configuration.cs
@@ -56,9 +56,9 @@ public class Configuration {
     ///     Version of the package.
     /// </summary>
     /// <value>Version of the package.</value>
-    public const string Version = "0.3.2";
+    public const string Version = "0.4.0";
 
-    private const string DefaultUserAgent = "openfga-sdk dotnet/0.3.2";
+    private const string DefaultUserAgent = "openfga-sdk dotnet/0.4.0";
 
     #endregion Constants
 

--- a/src/OpenFga.Sdk/OpenFga.Sdk.csproj
+++ b/src/OpenFga.Sdk/OpenFga.Sdk.csproj
@@ -12,7 +12,7 @@
     <Description>.NET SDK for OpenFGA</Description>
     <Copyright>OpenFGA</Copyright>
     <RootNamespace>OpenFga.Sdk</RootNamespace>
-    <Version>0.3.2</Version>
+    <Version>0.4.0</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\OpenFga.Sdk.xml</DocumentationFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Description

```
- chore!: remove excluded users from ListUsers response

BREAKING CHANGE:

This version removes the `ExcludedUsers` field from the `ListUsersResponse` and `ClientListUsersResponse` classes,
for more details see the [associated API change](https://github.com/openfga/api/pull/171).
```

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
