### PR TITLE
chore: remove dependecy to OpenTelemetry.Api

### DIFF
--- a/src/OpenFga.Sdk/OpenFga.Sdk.csproj
+++ b/src/OpenFga.Sdk/OpenFga.Sdk.csproj
@@ -33,8 +33,4 @@
     <None Include="../../README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.1"/>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
As the SDK is not using features from OpenTelemetry Api the dependency is not needed. 

## Description
The instrumentation of the SDK is done via dotnet mechanism (System.Diagnostic). 
The appliction which use the SDK should manage and configure the OpenTelemetry packages.


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

