### PR TITLE
feat: support nuget prereleases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
     needs: [test]
 
     steps:
@@ -78,9 +78,124 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
 
+  test-prerelease:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-test-')
+    needs: [test]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: 6.0.x
+          source-url: https://api.nuget.org/v3/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
+
+      # Extract version from tag (remove 'v' prefix)
+      - name: Extract version from tag
+        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      # Build with version override
+      - name: Build
+        run: dotnet build --no-restore --configuration Release -p:Version=${{ env.PACKAGE_VERSION }}
+
+      - name: Validate Package
+        run: |
+          # Check package was created with correct version
+          if [ ! -f "src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg" ]; then
+            echo "Package not found!"
+            exit 1
+          fi
+          
+          # Verify it's marked as prerelease
+          echo "Package version: ${{ env.PACKAGE_VERSION }}"
+          if [[ "${{ env.PACKAGE_VERSION }}" == *"-"* ]]; then
+            echo "✓ Prerelease version detected"
+          else
+            echo "✗ Not a prerelease version"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nuget-test-package
+          path: src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg
+
+      - name: Test Mode - Simulate Publishing
+        run: |
+          echo "🧪 TEST MODE: Would publish package to NuGet"
+          echo "Package: src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg"
+          echo "Package size: $(ls -lh src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg | awk '{print $5}')"
+          echo "✓ All prerelease workflow steps completed successfully"
+          echo "✓ Ready for actual prerelease publishing"
+
+  publish-prerelease:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-') && !contains(github.ref, '-test-')
+    needs: [test]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: 6.0.x
+          source-url: https://api.nuget.org/v3/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
+
+      # Extract version from tag (remove 'v' prefix)
+      - name: Extract version from tag
+        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      # Build with version override
+      - name: Build
+        run: dotnet build --no-restore --configuration Release -p:Version=${{ env.PACKAGE_VERSION }}
+
+      - name: Validate Package
+        run: |
+          # Check package was created with correct version
+          if [ ! -f "src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg" ]; then
+            echo "Package not found!"
+            exit 1
+          fi
+          
+          # Verify it's marked as prerelease
+          echo "Package version: ${{ env.PACKAGE_VERSION }}"
+          if [[ "${{ env.PACKAGE_VERSION }}" == *"-"* ]]; then
+            echo "✓ Prerelease version detected"
+          else
+            echo "✗ Not a prerelease version"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nuget-prerelease-package
+          path: src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg
+
+      - name: Publish Prerelease Package
+        run: dotnet nuget push src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${NUGET_AUTH_TOKEN}
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
+
   create-release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
     needs: publish
 
     permissions:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,65 +78,10 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
 
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-') && !contains(github.ref, '-test-')
-    needs: [test]
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-        with:
-          dotnet-version: 6.0.x
-          source-url: https://api.nuget.org/v3/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
-
-      # Extract version from tag (remove 'v' prefix)
-      - name: Extract version from tag
-        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      # Build with version override
-      - name: Build
-        run: dotnet build --no-restore --configuration Release -p:Version=${{ env.PACKAGE_VERSION }}
-
-      - name: Validate Package
-        run: |
-          # Check package was created with correct version
-          if [ ! -f "src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg" ]; then
-            echo "Package not found!"
-            exit 1
-          fi
-          
-          # Verify it's marked as prerelease
-          echo "Package version: ${{ env.PACKAGE_VERSION }}"
-          if [[ "${{ env.PACKAGE_VERSION }}" == *"-"* ]]; then
-            echo "✓ Prerelease version detected"
-          else
-            echo "✗ Not a prerelease version"
-            exit 1
-          fi
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: nuget-prerelease-package
-          path: src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg
-
-      - name: Publish Prerelease Package
-        run: dotnet nuget push src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${NUGET_AUTH_TOKEN}
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
-
   create-release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-test')
-    needs: publish
+    needs: [publish]
 
     permissions:
       contents: write

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-test')
     needs: [test]
 
     steps:
@@ -78,66 +78,6 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
 
-  test-prerelease:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-test-')
-    needs: [test]
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-        with:
-          dotnet-version: 6.0.x
-          source-url: https://api.nuget.org/v3/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
-
-      # Extract version from tag (remove 'v' prefix)
-      - name: Extract version from tag
-        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      # Build with version override
-      - name: Build
-        run: dotnet build --no-restore --configuration Release -p:Version=${{ env.PACKAGE_VERSION }}
-
-      - name: Validate Package
-        run: |
-          # Check package was created with correct version
-          if [ ! -f "src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg" ]; then
-            echo "Package not found!"
-            exit 1
-          fi
-          
-          # Verify it's marked as prerelease
-          echo "Package version: ${{ env.PACKAGE_VERSION }}"
-          if [[ "${{ env.PACKAGE_VERSION }}" == *"-"* ]]; then
-            echo "✓ Prerelease version detected"
-          else
-            echo "✗ Not a prerelease version"
-            exit 1
-          fi
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: nuget-test-package
-          path: src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg
-
-      - name: Test Mode - Simulate Publishing
-        run: |
-          echo "🧪 TEST MODE: Would publish package to NuGet"
-          echo "Package: src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg"
-          echo "Package size: $(ls -lh src/OpenFga.Sdk/bin/Release/OpenFga.Sdk.${{ env.PACKAGE_VERSION }}.nupkg | awk '{print $5}')"
-          echo "✓ All prerelease workflow steps completed successfully"
-          echo "✓ Ready for actual prerelease publishing"
-
-  publish-prerelease:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-') && !contains(github.ref, '-test-')
     needs: [test]
@@ -195,7 +135,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-test')
     needs: publish
 
     permissions:
@@ -209,5 +149,8 @@ jobs:
       - uses: Roang-zero1/github-create-release-action@57eb9bdce7a964e48788b9e78b5ac766cb684803 # v3.0.1
         with:
           version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+          prerelease_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-(alpha|beta|preview)\.[[:digit:]]+$
+          changelog_file: CHANGELOG.md
+          create_draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Modifies GitHub Workflow to make the following changes:
- prevents creating a release in GitHub for tags with a dash "-"
- Pushing tags like "v1.1-alpha.1" or "v1.1-dev.1" will trigger creation and publication of a pre-release nuget package but will not create a release in GitHub
- Pushing a tag like "v1.1-alpha.1" or "v1.1-dev.1" will trigger creation of a nuget package and testing of the process but will not publish the package to nuget

## References


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

