### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased](https://github.com/openfga/dotnet-sdk/compare/v0.5.1...HEAD)
+## [Unreleased](https://github.com/openfga/dotnet-sdk/compare/v0.6.0...HEAD)
+
+## v0.6.0
+
+### [0.6.0](https://github.com/openfga/dotnet-sdk/compare/v0.5.1...v0.6.0) (2025-09-30)
 
 - feat: add support for `start_time` parameter in `ReadChanges` endpoint
 - feat: update API definitions

--- a/src/OpenFga.Sdk/Configuration/Configuration.cs
+++ b/src/OpenFga.Sdk/Configuration/Configuration.cs
@@ -73,9 +73,9 @@ public class Configuration {
     ///     Version of the package.
     /// </summary>
     /// <value>Version of the package.</value>
-    public const string Version = "0.5.1";
+    public const string Version = "0.6.0";
 
-    private const string DefaultUserAgent = "openfga-sdk dotnet/0.5.1";
+    private const string DefaultUserAgent = "openfga-sdk dotnet/0.6.0";
 
     #endregion Constants
 

--- a/src/OpenFga.Sdk/OpenFga.Sdk.csproj
+++ b/src/OpenFga.Sdk/OpenFga.Sdk.csproj
@@ -12,7 +12,7 @@
     <Description>.NET SDK for OpenFGA</Description>
     <Copyright>OpenFGA</Copyright>
     <RootNamespace>OpenFga.Sdk</RootNamespace>
-    <Version>0.5.1</Version>
+    <Version>0.6.0</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\OpenFga.Sdk.xml</DocumentationFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Note: This is being rolled out first so that the v0.7.0 can focus on the .NET Standard 2.0 support, allowing users who face issues with that release to still be able to benefit from these other fixes.

Changes:
- feat: add support for `start_time` parameter in `ReadChanges` endpoint
- feat: update API definitions
- feat: support assertions context and contextual tuples
- feat: support contextual tuples in `Expand`
- feat!: support passing in name to filter in `ListStores`
- fix: remove dependency on OpenTelemetry.Api (#100) - thanks @m4tchl0ck
- fix: limit default retries to `3` from `15` (https://github.com/openfga/sdk-generator/pull/420) - thanks @ovindu-a
- fix: `ListRelations` should not swallow errors
- chore(docs): replace readable names with uuid to discourage storing PII in OpenFGA (https://github.com/openfga/sdk-generator/pull/433) - thanks @sccalabr

[!WARNING]
BREAKING CHANGES:
- The `ListStores` method now accepts a body parameter with an optional `Name` to filter the stores. This is a breaking change as it changes the method contract to allow passing in a body with the name.


#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with a new v0.6.0 release section, date, features, fixes, and noted breaking changes.
  * Adjusted Unreleased link to track from v0.6.0.

* **Chores**
  * Bumped package version to 0.6.0.
  * Updated default user agent string to reflect version 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->