### PR TITLE
test: reduce unnecessary test warnings

### DIFF
--- a/src/OpenFga.Sdk.Test/OpenFga.Sdk.Test.csproj
+++ b/src/OpenFga.Sdk.Test/OpenFga.Sdk.Test.csproj
@@ -6,23 +6,33 @@
     <RootNamespace>OpenFga.Sdk.Test</RootNamespace>
     <TargetFrameworks>netcoreapp3.1;net48;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <LangVersion>10.0</LangVersion>
+    <IsNet8OrGreater>$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))</IsNet8OrGreater>
+    <!-- Suppress warnings that don't apply to test projects:
+         NU1701: Package compatibility warnings
+         CS1591: Missing XML documentation comments
+         CS1574,CS1712,CS1573: XML documentation reference warnings
+         CS0618: Obsolete API usage (intentional for backward compatibility testing)
+         CS8618: Non-nullable field must contain a non-null value when exiting constructor -->
+    <NoWarn>$(NoWarn);NU1701;CS1591;CS1574;CS1712;CS1573;CS0618;CS8618</NoWarn>
   </PropertyGroup>
 
-  <!-- .NET 8.0 and .NET 9.0 specific settings -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
+  <!-- .NET 8.0+ specific settings -->
+  <PropertyGroup Condition="'$(IsNet8OrGreater)' == 'true'">
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <!-- .NET Core 3.1 specific settings -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <!-- Pre-.NET 8.0 settings (requires explicit LangVersion) -->
+  <PropertyGroup Condition="'$(IsNet8OrGreater)' != 'true'">
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <!-- .NET Framework 4.8 specific settings -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
-    <LangVersion>10.0</LangVersion>
-    <Nullable>enable</Nullable>
+  <!-- Suppress TFM support warnings for netcoreapp3.1 -->
+  <!-- These packages work fine with netcoreapp3.1 despite not being officially tested -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <!-- Packages needed for .NET versions < .NET 8 -->


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR updates `OpenFga.Sdk.Test.csproj` to address some of the irrelevant warnings emitted when running tests:

- `CS8632` was fixed to ensure consistent nullable reference type handling across all frameworks.
- `NU1701` was being thrown because `xunit` uses .NET framework compatibility mode for .NET Core targets. These are harmless warnings that we can ignore.
- `TFM Support Build Warnings` was being thrown because `netcoreapp3.1` is not officially supported by `System.Text.Json`, `Microsoft.Extensions.*`, `System.IO.Pipelines`, etc. These are ignorable because we're running an unsupported configuration intentionally
- `CS1591`, `CS1574`, `CS1712`, and `CS1573` were being thrown because our tests don't have XML documentation; we don't need that in our tests, and it can be ignored
- `CS0618` was being thrown because we're intentionally running tests against deprecated APIs to migrate validation paths
- `CS8618` was being thrown because our test classes often have fields initialized by the test framework, which is common for test fixtures and mocking, and is therefore ignorable

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal build configuration improvements for test infrastructure across multiple .NET versions.

---

**Note:** This release contains no user-facing changes. Updates are limited to development and testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->