### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased](https://github.com/openfga/dotnet-sdk/compare/v0.7.0...HEAD)
+## [Unreleased](https://github.com/openfga/dotnet-sdk/compare/v0.8.0...HEAD)
+
+## v0.8.0
+
+### [0.8.0](https://github.com/openfga/dotnet-sdk/compare/v0.7.0...v0.8.0) (2025-10-22)
 
 - feat!: add per-request custom headers support
   - `DefaultHeaders` support to `ClientConfiguration` for headers sent with every request

--- a/src/OpenFga.Sdk/Configuration/Configuration.cs
+++ b/src/OpenFga.Sdk/Configuration/Configuration.cs
@@ -136,9 +136,9 @@ public class Configuration {
     ///     Version of the package.
     /// </summary>
     /// <value>Version of the package.</value>
-    public const string Version = "0.7.0";
+    public const string Version = "0.8.0";
 
-    private const string DefaultUserAgent = "openfga-sdk dotnet/0.7.0";
+    private const string DefaultUserAgent = "openfga-sdk dotnet/0.8.0";
 
     #endregion Constants
 

--- a/src/OpenFga.Sdk/OpenFga.Sdk.csproj
+++ b/src/OpenFga.Sdk/OpenFga.Sdk.csproj
@@ -13,7 +13,7 @@
     <Description>.NET SDK for OpenFGA</Description>
     <Copyright>OpenFGA</Copyright>
     <RootNamespace>OpenFga.Sdk</RootNamespace>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\OpenFga.Sdk.xml</DocumentationFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
- feat!: add per-request custom headers support
  - `DefaultHeaders` support to `ClientConfiguration` for headers sent with every request
  - per-request headers support via `Headers` property on all client options classes
  - `IRequestOptions` interface and `RequestOptions` class for API-level header support
  - `IClientRequestOptions` interface and `ClientRequestOptions` class for client-level header support
  - add header validation to prevent overriding of reserved headers
- feat: add write conflict resolution options
  - `ConflictOptions` to control behavior for duplicate writes and missing deletes
  - `OnDuplicateWrites` option: `Error` (default) or `Ignore` for handling duplicate tuple writes
  - `OnMissingDeletes` option: `Error` (default) or `Ignore` for handling missing tuple deletes
  - Available in `ClientWriteOptions.Conflict` property
- feat: add Retry-After header support for rate limiting
  - Retry logic now respects `Retry-After` header from HTTP 429 responses
  - Falls back to exponential backoff when Retry-After header is missing or invalid

> [!WARNING]
> BREAKING CHANGES:

- **OpenFgaApi methods**: All API methods now accept an `IRequestOptions? options` parameter. If you are using the low-level `OpenFgaApi` directly, you may need to update your calls:

  Before:

  ```csharp
  await api.Check(storeId, body, cancellationToken);
  ```

  After:

  ```csharp
  var options = new RequestOptions {
      Headers = new Dictionary<string, string> { { "X-Custom-Header", "value" } }
  };
  await api.Check(storeId, body, options, cancellationToken);
  ```

- **ClientRequestOptions renamed**: The base client request options interface has been renamed from `ClientRequestOptions` to `IClientRequestOptions` to better follow .NET naming conventions. A concrete `ClientRequestOptions` class is now also available. If you were casting to or implementing this interface, update your code:

  Before:

  ```csharp
  var options = obj as ClientRequestOptions;
  ```

  After:

  ```csharp
  var options = obj as IClientRequestOptions;
  ```

Note: If you are using the high-level `OpenFgaClient`, no changes are required to your existing code. The new headers functionality is additive via the existing options parameters.