### PR TITLE
fix: lower the min version of system.* dependencies and cleaned up unnecessary ones

### DIFF
--- a/src/OpenFga.Sdk/OpenFga.Sdk.csproj
+++ b/src/OpenFga.Sdk/OpenFga.Sdk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -38,18 +38,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <!-- Common package references for all frameworks -->
-  <ItemGroup>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.9" />
-  </ItemGroup>
-
   <!-- Packages needed for .NET versions < .NET 8 -->
   <ItemGroup Condition="'$(IsNet8OrGreater)' != 'true'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.9" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.9" />
-    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <!-- .NET Framework 4.8 specific packages -->


### PR DESCRIPTION
## Description

#### What problem is being solved?
https://github.com/openfga/dotnet-sdk/issues/143

#### How is it being solved?
- Lowered the minimum required version of the System.* packages to 8.* to allow for broader set of consumers
- Removed unnecessary dependencies to avoid unnecessary dependency conflicts

## References
* closes https://github.com/openfga/dotnet-sdk/issues/143

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies and versions for non-.NET 8 framework targets to optimize compatibility and support across different .NET versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->