### PR TITLE
chore(ci): add trusted publishing to nuget & dual publish to GitHub Registry

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -235,7 +235,7 @@ jobs:
           path: ./dist
 
       - name: NuGet login (OIDC)
-        uses: NuGet/login@v1
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -206,6 +206,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-test')
     needs: [pack]
+    permissions:
+      id-token: write # For OIDC authentication with NuGet.org
+      packages: write # For publishing to the GitHub Nuget Registry
+
     steps:
       - name: Checkout code
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -230,14 +234,27 @@ jobs:
           name: nuget-package
           path: ./dist
 
-      - name: Publish
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish to NuGet
         run: |
-          echo "Publishing primary package (.nupkg)...";
-          dotnet nuget push dist/OpenFga.Sdk.*.nupkg --api-key ${NUGET_AUTH_TOKEN} --skip-duplicate --source https://api.nuget.org/v3/index.json
-          echo "Publishing symbol package (.snupkg)...";
-          dotnet nuget push dist/OpenFga.Sdk.*.snupkg --api-key ${NUGET_AUTH_TOKEN} --skip-duplicate --source https://api.nuget.org/v3/index.json || echo "No symbol package found or already published."
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
+          echo "Publishing primary package to NuGet (.nupkg)...";
+          dotnet nuget push dist/OpenFga.Sdk.*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --skip-duplicate --source https://api.nuget.org/v3/index.json
+          echo "Publishing symbol package to NuGet (.snupkg)...";
+          dotnet nuget push dist/OpenFga.Sdk.*.snupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --skip-duplicate --source https://api.nuget.org/v3/index.json || echo "No symbol package found or already published."
+
+      - name: Publish to GitHub Package Registry
+        continue-on-error: true
+        run: |
+          echo "Publishing primary package to GitHub Package Registry (.nupkg)...";
+          dotnet nuget push dist/OpenFga.Sdk.*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --source https://nuget.pkg.github.com/openfga/index.json
+          echo "Publishing symbol package to GitHub Package Registry (.snupkg)...";
+          dotnet nuget push dist/OpenFga.Sdk.*.snupkg --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --source https://nuget.pkg.github.com/openfga/index.json || echo "No symbol package found or already published."
+
   create-release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-test')


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Documentation on trusted publishing: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

closes #123 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched package publishing to OIDC-based authentication with explicit permissions and a dedicated login step.
  * Added publishing to GitHub Package Registry in addition to NuGet, with tolerant behavior if symbol packages are absent.
  * Updated publish logging to show targets and paths more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->