### PR TITLE
feat: batch check fallback to client level authmodel ID

### DIFF
--- a/src/OpenFga.Sdk.Test/Client/OpenFgaClientTests.cs
+++ b/src/OpenFga.Sdk.Test/Client/OpenFgaClientTests.cs
@@ -2942,7 +2942,55 @@ public class OpenFgaClientTests : IDisposable {
 
         Assert.NotNull(response);
         Assert.NotNull(capturedRequestBody);
-        Assert.Contains(clientAuthModelId, capturedRequestBody);
+        var batchCheckRequest = JsonSerializer.Deserialize<BatchCheckRequest>(capturedRequestBody!);
+        Assert.NotNull(batchCheckRequest);
+        Assert.Equal(clientAuthModelId, batchCheckRequest.AuthorizationModelId);
+    }
+
+    /// <summary>
+    /// Test BatchCheck falls back to client-level StoreId when not specified per-call
+    /// </summary>
+    [Fact]
+    public async Task BatchCheck_FallsBackToClientLevelStoreId() {
+        const string clientStoreId = "01H0H015178Y2V4CX10C2KGHF4";
+        var config = new ClientConfiguration() {
+            StoreId = clientStoreId,
+            ApiUrl = _apiUrl,
+        };
+
+        var expectedResponse = new BatchCheckResponse {
+            Result = new Dictionary<string, BatchCheckSingleResult> {
+                { "corr-1", new BatchCheckSingleResult { Allowed = true } }
+            }
+        };
+
+        Uri? capturedRequestUri = null;
+        var (client, _) = CreateTestClientForHeaders(expectedResponse, req => {
+            if (req.RequestUri?.AbsoluteUri.EndsWith("/batch-check") == true &&
+                req.Method == HttpMethod.Post) {
+                capturedRequestUri = req.RequestUri;
+                return true;
+            }
+            return false;
+        }, config);
+
+        var body = new ClientBatchCheckRequest {
+            Checks = new List<ClientBatchCheckItem> {
+                new() {
+                    User = "user:anne",
+                    Relation = "reader",
+                    Object = "document:budget",
+                    CorrelationId = "corr-1"
+                }
+            }
+        };
+
+        // No StoreId in per-call options — should fall back to client-level config
+        var response = await client.BatchCheck(body);
+
+        Assert.NotNull(response);
+        Assert.NotNull(capturedRequestUri);
+        Assert.Contains($"/stores/{clientStoreId}/", capturedRequestUri.AbsoluteUri);
     }
 
     /// <summary>

--- a/src/OpenFga.Sdk.Test/Client/OpenFgaClientTests.cs
+++ b/src/OpenFga.Sdk.Test/Client/OpenFgaClientTests.cs
@@ -2899,6 +2899,53 @@ public class OpenFgaClientTests : IDisposable {
     }
 
     /// <summary>
+    /// Test BatchCheck falls back to client-level AuthorizationModelId when not specified per-call
+    /// </summary>
+    [Fact]
+    public async Task BatchCheck_FallsBackToClientLevelAuthorizationModelId() {
+        const string clientAuthModelId = "01GXSA8YR785C4FYS3C0RTG7B1";
+        var config = new ClientConfiguration() {
+            StoreId = _storeId,
+            ApiUrl = _apiUrl,
+            AuthorizationModelId = clientAuthModelId
+        };
+
+        var expectedResponse = new BatchCheckResponse {
+            Result = new Dictionary<string, BatchCheckSingleResult> {
+                { "corr-1", new BatchCheckSingleResult { Allowed = true } }
+            }
+        };
+
+        string? capturedRequestBody = null;
+        var (client, _) = CreateTestClientForHeaders(expectedResponse, req => {
+            if (req.RequestUri?.AbsoluteUri.EndsWith("/batch-check") == true &&
+                req.Method == HttpMethod.Post) {
+                capturedRequestBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+                return true;
+            }
+            return false;
+        }, config);
+
+        var body = new ClientBatchCheckRequest {
+            Checks = new List<ClientBatchCheckItem> {
+                new() {
+                    User = "user:anne",
+                    Relation = "reader",
+                    Object = "document:budget",
+                    CorrelationId = "corr-1"
+                }
+            }
+        };
+
+        // No AuthorizationModelId in per-call options — should fall back to client-level config
+        var response = await client.BatchCheck(body);
+
+        Assert.NotNull(response);
+        Assert.NotNull(capturedRequestBody);
+        Assert.Contains(clientAuthModelId, capturedRequestBody);
+    }
+
+    /// <summary>
     /// Test CreateStore with custom headers
     /// </summary>
     [Fact]

--- a/src/OpenFga.Sdk/Client/Client.cs
+++ b/src/OpenFga.Sdk/Client/Client.cs
@@ -547,7 +547,7 @@ public class OpenFgaClient : IOpenFgaClient, IDisposable {
         // Create options with headers for this batch
         var batchOptions = new ClientBatchCheckOptions {
             StoreId = options?.StoreId,
-            AuthorizationModelId = options?.AuthorizationModelId,
+            AuthorizationModelId = GetAuthorizationModelId(options),
             Consistency = options?.Consistency,
             Headers = headers
         };

--- a/src/OpenFga.Sdk/Client/Client.cs
+++ b/src/OpenFga.Sdk/Client/Client.cs
@@ -546,7 +546,7 @@ public class OpenFgaClient : IOpenFgaClient, IDisposable {
 
         // Create options with headers for this batch
         var batchOptions = new ClientBatchCheckOptions {
-            StoreId = options?.StoreId,
+            StoreId = GetStoreId(options),
             AuthorizationModelId = GetAuthorizationModelId(options),
             Consistency = options?.Consistency,
             Headers = headers


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch check operations to properly use the client-level authorization model ID as a fallback when no operation-specific ID is provided, ensuring consistent behavior across all API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->