### PR TITLE
feat: support OAuth2 scopes for client credentials authentication

### DIFF
--- a/src/OpenFga.Sdk.Test/Api/OpenFgaApiTests.cs
+++ b/src/OpenFga.Sdk.Test/Api/OpenFgaApiTests.cs
@@ -269,6 +269,7 @@ namespace OpenFga.Sdk.Test.Api {
             Assert.Equal("Required parameter ApiTokenIssuer was not defined when calling Configuration.",
                 exceptionMissingApiTokenIssuer.Message);
 
+            // ApiAudience is optional — standard OAuth2 servers don't require it
             var missingApiAudienceConfig = new SdkConfiguration {
                 StoreId = _storeId,
                 ApiHost = _host,
@@ -282,12 +283,8 @@ namespace OpenFga.Sdk.Test.Api {
                 }
             };
 
-            void ActionMissingApiAudience() =>
-                missingApiAudienceConfig.EnsureValid();
-            var exceptionMissingApiAudience =
-                Assert.Throws<FgaRequiredParamError>(ActionMissingApiAudience);
-            Assert.Equal("Required parameter ApiAudience was not defined when calling Configuration.",
-                exceptionMissingApiAudience.Message);
+            var exception = Record.Exception(() => missingApiAudienceConfig.EnsureValid());
+            Assert.Null(exception);
         }
 
         /// <summary>

--- a/src/OpenFga.Sdk.Test/ApiClient/OAuth2ClientTests.cs
+++ b/src/OpenFga.Sdk.Test/ApiClient/OAuth2ClientTests.cs
@@ -307,6 +307,159 @@ namespace OpenFga.Sdk.Test.ApiClient {
 
         #endregion
 
+        #region OAuth2 Scopes
+
+        [Fact]
+        public async Task OAuth2_ExchangeToken_IncludesScopesInRequest() {
+            var credentials = new Credentials {
+                Method = CredentialsMethod.ClientCredentials,
+                Config = new CredentialsConfig {
+                    ClientId = TestClientId,
+                    ClientSecret = TestClientSecret,
+                    ApiTokenIssuer = TestTokenIssuer,
+                    ApiAudience = TestAudience,
+                    Scopes = "scope1 scope2"
+                }
+            };
+            var retryParams = CreateTestRetryParams(maxRetry: 0, minWaitInMs: 10);
+
+            string? requestBody = null;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                    return CreateTokenResponse();
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var configuration = new SdkConfiguration { ApiUrl = Constants.FgaConstants.TestApiUrl };
+            var baseClient = new BaseClient(configuration, httpClient);
+            var metrics = new Metrics(configuration);
+
+            var oauth2Client = new OAuth2Client(credentials, baseClient, retryParams, metrics);
+            await oauth2Client.GetAccessTokenAsync();
+
+            Assert.NotNull(requestBody);
+            Assert.Contains("scope=scope1+scope2", requestBody);
+        }
+
+        [Fact]
+        public async Task OAuth2_ExchangeToken_OmitsScopeWhenNotConfigured() {
+            var credentials = CreateTestCredentials();
+            var retryParams = CreateTestRetryParams(maxRetry: 0, minWaitInMs: 10);
+
+            string? requestBody = null;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                    return CreateTokenResponse();
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var configuration = new SdkConfiguration { ApiUrl = Constants.FgaConstants.TestApiUrl };
+            var baseClient = new BaseClient(configuration, httpClient);
+            var metrics = new Metrics(configuration);
+
+            var oauth2Client = new OAuth2Client(credentials, baseClient, retryParams, metrics);
+            await oauth2Client.GetAccessTokenAsync();
+
+            Assert.NotNull(requestBody);
+            Assert.DoesNotContain("scope=", requestBody);
+        }
+
+        [Fact]
+        public async Task OAuth2_ExchangeToken_WorksWithoutAudience() {
+            var credentials = new Credentials {
+                Method = CredentialsMethod.ClientCredentials,
+                Config = new CredentialsConfig {
+                    ClientId = TestClientId,
+                    ClientSecret = TestClientSecret,
+                    ApiTokenIssuer = TestTokenIssuer,
+                    Scopes = "read write"
+                }
+            };
+            var retryParams = CreateTestRetryParams(maxRetry: 0, minWaitInMs: 10);
+
+            string? requestBody = null;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                    return CreateTokenResponse();
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var configuration = new SdkConfiguration { ApiUrl = Constants.FgaConstants.TestApiUrl };
+            var baseClient = new BaseClient(configuration, httpClient);
+            var metrics = new Metrics(configuration);
+
+            var oauth2Client = new OAuth2Client(credentials, baseClient, retryParams, metrics);
+            var token = await oauth2Client.GetAccessTokenAsync();
+
+            Assert.Equal("test-access-token", token);
+            Assert.NotNull(requestBody);
+            Assert.DoesNotContain("audience=", requestBody);
+            Assert.Contains("scope=read+write", requestBody);
+        }
+
+        [Fact]
+        public async Task OAuth2_ExchangeToken_IncludesBothAudienceAndScopes() {
+            var credentials = new Credentials {
+                Method = CredentialsMethod.ClientCredentials,
+                Config = new CredentialsConfig {
+                    ClientId = TestClientId,
+                    ClientSecret = TestClientSecret,
+                    ApiTokenIssuer = TestTokenIssuer,
+                    ApiAudience = TestAudience,
+                    Scopes = "openid profile"
+                }
+            };
+            var retryParams = CreateTestRetryParams(maxRetry: 0, minWaitInMs: 10);
+
+            string? requestBody = null;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                    return CreateTokenResponse();
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var configuration = new SdkConfiguration { ApiUrl = Constants.FgaConstants.TestApiUrl };
+            var baseClient = new BaseClient(configuration, httpClient);
+            var metrics = new Metrics(configuration);
+
+            var oauth2Client = new OAuth2Client(credentials, baseClient, retryParams, metrics);
+            await oauth2Client.GetAccessTokenAsync();
+
+            Assert.NotNull(requestBody);
+            Assert.Contains("audience=test-audience", requestBody);
+            Assert.Contains("scope=openid+profile", requestBody);
+        }
+
+        #endregion
+
         #region ApiTokenIssuer Path Handling
 
         [Theory]

--- a/src/OpenFga.Sdk.Test/ApiClient/OAuth2ClientTests.cs
+++ b/src/OpenFga.Sdk.Test/ApiClient/OAuth2ClientTests.cs
@@ -331,8 +331,10 @@ namespace OpenFga.Sdk.Test.ApiClient {
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
-                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                .Returns(async (HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content is null
+                        ? null
+                        : await request.Content.ReadAsStringAsync();
                     return CreateTokenResponse();
                 });
 
@@ -361,8 +363,10 @@ namespace OpenFga.Sdk.Test.ApiClient {
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
-                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                .Returns(async (HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content is null
+                        ? null
+                        : await request.Content.ReadAsStringAsync();
                     return CreateTokenResponse();
                 });
 
@@ -399,8 +403,10 @@ namespace OpenFga.Sdk.Test.ApiClient {
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
-                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                .Returns(async (HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content is null
+                        ? null
+                        : await request.Content.ReadAsStringAsync();
                     return CreateTokenResponse();
                 });
 
@@ -440,8 +446,10 @@ namespace OpenFga.Sdk.Test.ApiClient {
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync((HttpRequestMessage request, CancellationToken ct) => {
-                    requestBody = request.Content?.ReadAsStringAsync().Result;
+                .Returns(async (HttpRequestMessage request, CancellationToken ct) => {
+                    requestBody = request.Content is null
+                        ? null
+                        : await request.Content.ReadAsStringAsync();
                     return CreateTokenResponse();
                 });
 

--- a/src/OpenFga.Sdk/ApiClient/OAuth2Client.cs
+++ b/src/OpenFga.Sdk/ApiClient/OAuth2Client.cs
@@ -131,8 +131,12 @@ public class OAuth2Client {
             { "grant_type", "client_credentials" }
         };
 
-        if (credentialsConfig.Config.ApiAudience != null) {
+        if (!string.IsNullOrWhiteSpace(credentialsConfig.Config.ApiAudience)) {
             _authRequest["audience"] = credentialsConfig.Config.ApiAudience;
+        }
+
+        if (!string.IsNullOrWhiteSpace(credentialsConfig.Config.Scopes)) {
+            _authRequest["scope"] = credentialsConfig.Config.Scopes;
         }
 
         _retryHandler = new RetryHandler(retryParams);

--- a/src/OpenFga.Sdk/Configuration/Credentials.cs
+++ b/src/OpenFga.Sdk/Configuration/Credentials.cs
@@ -71,9 +71,19 @@ public interface IClientCredentialsConfig {
 
     /// <summary>
     ///     Gets or sets the API Audience.
+    ///     Optional — only required for Auth0-style token servers.
+    ///     Standard OAuth2 servers typically do not use this parameter.
     /// </summary>
     /// <value>API Audience.</value>
     string? ApiAudience { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the OAuth2 scopes to request during the client credentials token exchange.
+    ///     Space-separated string of scopes (e.g. "scope1 scope2").
+    ///     Optional.
+    /// </summary>
+    /// <value>OAuth2 Scopes.</value>
+    string? Scopes { get; set; }
 }
 
 public interface ICredentialsConfig : IClientCredentialsConfig, IApiTokenConfig { }
@@ -83,6 +93,7 @@ public struct CredentialsConfig : ICredentialsConfig {
     public string? ClientSecret { get; set; }
     public string? ApiTokenIssuer { get; set; }
     public string? ApiAudience { get; set; }
+    public string? Scopes { get; set; }
     public string? ApiToken { get; set; }
 }
 
@@ -138,10 +149,6 @@ public class Credentials : IAuthCredentialsConfig {
 
                 if (string.IsNullOrWhiteSpace(Config?.ApiTokenIssuer)) {
                     throw new FgaRequiredParamError("Configuration", nameof(Config.ApiTokenIssuer));
-                }
-
-                if (string.IsNullOrWhiteSpace(Config?.ApiAudience)) {
-                    throw new FgaRequiredParamError("Configuration", nameof(Config.ApiAudience));
                 }
 
                 // Validate that the normalized URL is well-formed


### PR DESCRIPTION
- Add optional `Scopes` property to `IClientCredentialsConfig` and `CredentialsConfig`
- Include `scope` parameter in OAuth2 token exchange request when configured
- Make `ApiAudience` optional (standard OAuth2 servers don't require it)
- Add tests for scopes inclusion, omission, and combined audience+scopes

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth2 scopes support to client credentials configuration, allowing scopes to be included in token requests.

* **Bug Fixes**
  * `ApiAudience` parameter is now optional for OAuth2 authentication.

* **Tests**
  * Added new test coverage for OAuth2 token request behavior with various scopes and audience configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/dotnet-sdk/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->