### PR TITLE
fix: compare contextual tuples by value

### DIFF
--- a/src/OpenFga.Sdk.Test/Models/Client/ClientCheckRequestTest.cs
+++ b/src/OpenFga.Sdk.Test/Models/Client/ClientCheckRequestTest.cs
@@ -1,0 +1,44 @@
+using OpenFga.Sdk.Client.Model;
+using System.Collections.Generic;
+using Xunit;
+
+namespace OpenFga.Sdk.Test.Models.Client;
+
+public class ClientCheckRequestTests {
+    [Fact]
+    public void Equals_ReturnsTrue_WhenContextualTuplesHaveEqualValues() {
+        var request1 = CreateRequest("document:budget");
+        var request2 = CreateRequest("document:budget");
+
+        Assert.True(request1.Equals(request2));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalse_WhenContextualTuplesHaveDifferentValues() {
+        var request1 = CreateRequest("document:budget");
+        var request2 = CreateRequest("document:forecast");
+
+        Assert.False(request1.Equals(request2));
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameValue_WhenContextualTuplesHaveEqualValues() {
+        var request1 = CreateRequest("document:budget");
+        var request2 = CreateRequest("document:budget");
+
+        Assert.Equal(request1.GetHashCode(), request2.GetHashCode());
+    }
+
+    private static ClientCheckRequest CreateRequest(string contextualObject) => new() {
+        User = "user:anne",
+        Relation = "viewer",
+        Object = "document:roadmap",
+        ContextualTuples = new List<ClientTupleKey> {
+            new() {
+                User = "user:anne",
+                Relation = "editor",
+                Object = contextualObject,
+            },
+        },
+    };
+}

--- a/src/OpenFga.Sdk/Client/Model/ClientCheckRequest.cs
+++ b/src/OpenFga.Sdk/Client/Model/ClientCheckRequest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -75,7 +76,8 @@ public class ClientCheckRequest : IClientCheckRequest, IEquatable<ClientCheckReq
             (
                 ContextualTuples == input.ContextualTuples ||
                 (ContextualTuples != null &&
-                 ContextualTuples.Equals(input.ContextualTuples))
+                 input.ContextualTuples != null &&
+                 ContextualTuples.SequenceEqual(input.ContextualTuples))
             ) &&
             (
                 this.Context == input.Context ||
@@ -112,7 +114,10 @@ public class ClientCheckRequest : IClientCheckRequest, IEquatable<ClientCheckReq
             }
 
             if (ContextualTuples != null) {
-                hashCode = (hashCode * 9923) + ContextualTuples.GetHashCode();
+                hashCode = (hashCode * 9923) + ContextualTuples.Count;
+                foreach (var contextualTuple in ContextualTuples) {
+                    hashCode = (hashCode * 9923) + (contextualTuple?.GetHashCode() ?? 0);
+                }
             }
 
             if (Context != null) {


### PR DESCRIPTION
## Summary

- compare `ClientCheckRequest` contextual tuple sequences by value instead of list reference
- derive the contextual tuple portion of the hash code from its contents
- add regression coverage for equal and different tuple values and hash consistency

## Testing

- `dotnet format OpenFga.Sdk.sln --verify-no-changes --include <changed files> --severity info --no-restore`
- `dotnet build OpenFga.Sdk.sln --configuration Release --no-restore`
- `dotnet test src/OpenFga.Sdk.Test/OpenFga.Sdk.Test.csproj --configuration Release --framework net48 --no-build --no-restore` (357 passed)
- `dotnet test src/OpenFga.Sdk.Test/OpenFga.Sdk.Test.csproj --configuration Release --framework net8.0 --no-build --no-restore` (357 passed)
- `dotnet test src/OpenFga.Sdk.Test/OpenFga.Sdk.Test.csproj --configuration Release --framework net9.0 --no-build --no-restore` (357 passed)

Fixes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equality checks for client check requests containing contextual tuples.
  * Requests with identical tuple values are now recognized as equal, while differing values are correctly distinguished.
  * Updated hash calculations to remain consistent with equality behavior.

* **Tests**
  * Added coverage for contextual tuple equality and hash-code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->